### PR TITLE
correct maintainer surname spelling

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,14 +3,14 @@ Title: Geographical Detectors for Assessing Spatial Factors
 Version: 10.9
 Authors@R: 
     c(
-      person(given = "Wenbo", family = "Lyu",
-             email = "lyu.geosocial@gmail.com", 
-             role = c("aut", "cre"),
-             comment = c(ORCID = "0009-0002-6003-3800")),
       person(given = "Yongze", family = "Song",
              email = "yongze.song@outlook.com", 
              role = c("aut", "cph"),
-             comment = c(ORCID = "0000-0003-3420-9622"))
+             comment = c(ORCID = "0000-0003-3420-9622")),
+      person(given = "Wenbo", family = "Lyu",
+             email = "lyu.geosocial@gmail.com", 
+             role = c("aut", "cre"),
+             comment = c(ORCID = "0009-0002-6003-3800"))
      )
 Description: Geographical detectors for measuring spatial stratified heterogeneity,
              as described in Jinfeng Wang (2010) <doi:10.1080/13658810802443457> and 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,14 +3,14 @@ Title: Geographical Detectors for Assessing Spatial Factors
 Version: 10.9
 Authors@R: 
     c(
+      person(given = "Wenbo", family = "Lyu",
+             email = "lyu.geosocial@gmail.com", 
+             role = c("aut", "cre"),
+             comment = c(ORCID = "0009-0002-6003-3800"),
       person(given = "Yongze", family = "Song",
              email = "yongze.song@outlook.com", 
              role = c("aut", "cph"),
-             comment = c(ORCID = "0000-0003-3420-9622")),
-      person(given = "Wenbo", family = "Lv",
-             email = "lyu.geosocial@gmail.com", 
-             role = c("aut", "cre"),
-             comment = c(ORCID = "0009-0002-6003-3800"))
+             comment = c(ORCID = "0000-0003-3420-9622")))
      )
 Description: Geographical detectors for measuring spatial stratified heterogeneity,
              as described in Jinfeng Wang (2010) <doi:10.1080/13658810802443457> and 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,11 +6,11 @@ Authors@R:
       person(given = "Wenbo", family = "Lyu",
              email = "lyu.geosocial@gmail.com", 
              role = c("aut", "cre"),
-             comment = c(ORCID = "0009-0002-6003-3800"),
+             comment = c(ORCID = "0009-0002-6003-3800")),
       person(given = "Yongze", family = "Song",
              email = "yongze.song@outlook.com", 
              role = c("aut", "cph"),
-             comment = c(ORCID = "0000-0003-3420-9622")))
+             comment = c(ORCID = "0000-0003-3420-9622"))
      )
 Description: Geographical detectors for measuring spatial stratified heterogeneity,
              as described in Jinfeng Wang (2010) <doi:10.1080/13658810802443457> and 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # GD 10.9
 
+* Correct maintainer surname spelling.
+
 # GD 10.8
 
 * Recommended to install `gdverse` (>= 1.3).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,5 @@
 # GD 10.9
 
-* Correct maintainer surname spelling.
-
 # GD 10.8
 
 * Recommended to install `gdverse` (>= 1.3).

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -16,10 +16,10 @@ navbar:
         href: articles/GD.html
 
 authors:
+  Wenbo Lyu:
+    href: https://spatlyu.github.io/
   Yongze Song:
     href: https://yongzesong.com/
-  Wenbo Lv:
-    href: https://spatlyu.github.io/
 
 reference:
 - title: Model

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -16,10 +16,10 @@ navbar:
         href: articles/GD.html
 
 authors:
-  Wenbo Lyu:
-    href: https://spatlyu.github.io/
   Yongze Song:
     href: https://yongzesong.com/
+  Wenbo Lyu:
+    href: https://spatlyu.github.io/
 
 reference:
 - title: Model


### PR DESCRIPTION
This PR updates the maintainer name from `Wenbo Lv` to `Wenbo Lyu` to align with my official passport spelling.

## Background

- **Chinese name**: 吕文博
- **Previous English name**: Wenbo Lv
- **Passport spelling**: Wenbo Lyu

The spelling `Lyu` is the standardized ASCII representation of the surname "吕" (Lü) used in official Chinese documents, including passports. This change ensures consistency across all official and academic records.

## Changes

- Updated maintainer name in `DESCRIPTION` file
- Updated author information in package metadata